### PR TITLE
Улучшены стили для результатов голосования

### DIFF
--- a/source.styl
+++ b/source.styl
@@ -480,6 +480,23 @@ body.nl .layout__elevator
             color:  link-default !important
             &:hover
                 color: link-hover !important
+    
+    &__polling-title
+        color: main-font-color
+
+// block with polling and results. Shouldn't be transparent
+.default_block_polling
+    opacity: 1 !important
+
+.poll-result
+    &__data-label
+        color: main-font-color
+
+    &__progress
+        background: #78A7C4;
+
+    &__progress_winner
+        background: #2B6DAC
 
 .stacked-menu
     &__item-text


### PR DESCRIPTION
Текст теперь белый, прогресс бар поярче, чтобы более выделялся в более тёмной теме и отключено цветовой затемнение вне фокуса.
Было.
![default](https://user-images.githubusercontent.com/32711843/36050015-de2b4316-0df5-11e8-86fb-3786993bd788.png)
Стало.
![default](https://user-images.githubusercontent.com/32711843/36050038-f65efe50-0df5-11e8-9363-2d05fa527078.png)
