### PR TITLE
Добавление поддержки светлого цвета шрифта для некоторых тегов.

### DIFF
--- a/source.css
+++ b/source.css
@@ -20,6 +20,9 @@ body {
 body.nl .layout {
   background-color: #333;
 }
+.h-info p {
+  color: #bbb;
+}
 #layout,
 #xpanel,
 .to_top {
@@ -1421,31 +1424,12 @@ code.hljs .ini .hljs-keyword {
   color: inherit;
 }
 :not(.voting-wjt):not(.voting-wjt__counter):not(.favorite-wjt) > button,
-:not(.voting-wjt):not(.voting-wjt__counter):not(.favorite-wjt) > button:focus,
-:not(.voting-wjt):not(.voting-wjt__counter):not(.favorite-wjt) > button:active,
-:not(.voting-wjt):not(.voting-wjt__counter):not(.favorite-wjt) > button:visited,
 :not(.wysiwyg_wrapper) > a.btn,
 :not(.wysiwyg_wrapper) > .btn-dropdown,
-:not(.wysiwyg_wrapper) > a.btn:focus,
-:not(.wysiwyg_wrapper) > .btn-dropdown:focus,
-:not(.wysiwyg_wrapper) > a.btn:active,
-:not(.wysiwyg_wrapper) > .btn-dropdown:active,
-:not(.wysiwyg_wrapper) > a.btn:visited,
-:not(.wysiwyg_wrapper) > .btn-dropdown:visited,
 a.habracut,
-a.habracut:focus,
-a.habracut:active,
-a.habracut:visited,
 .buttons a.button,
 .buttons a.button:active,
 .buttons a.button:focus,
-.buttons a.button:active:focus,
-.buttons a.button:focus:focus,
-.buttons a.button:active:active,
-.buttons a.button:focus:active,
-.buttons a.button:visited,
-.buttons a.button:active:visited,
-.buttons a.button:focus:visited,
 .buttons input[type=button],
 .buttons input[type=submit],
 .buttons input[type=button]:focus,

--- a/source.styl
+++ b/source.styl
@@ -101,6 +101,10 @@ body
     &.nl .layout
         background-color: main-bg
 
+// For habr info page (Improve?)
+.h-info p
+    color: main-font-color
+
 #layout, #xpanel, .to_top
     z-index: 1
 


### PR DESCRIPTION
Страница о HFM.
Было:
![default](https://user-images.githubusercontent.com/32711843/37532292-abd5e8d8-294f-11e8-98fc-12dd2cd7e645.png)
Стало:
![default](https://user-images.githubusercontent.com/32711843/37532368-e673e972-294f-11e8-9cb7-fd1994da6c70.png)
Не знаю, почему при компиляции часть кода из css выкинуло. Собирал версией `0.48.1`.

